### PR TITLE
fixes for running playframework 1.3 with Java 8 and lambdas

### DIFF
--- a/src/bytecodeparser/CodeParser.java
+++ b/src/bytecodeparser/CodeParser.java
@@ -50,7 +50,9 @@ public class CodeParser {
 			if(stop)
 				break;
 			int index = context.iterator.next();
-			Op op = Opcodes.OPCODES.get(context.iterator.byteAt(index)).init(context, index);
+            Op opcode = Opcodes.OPCODES.get(context.iterator.byteAt(index));
+            if(opcode == null) continue;
+            Op op = opcode.init(context, index);
 			opHandler.handle(op, index);
 		}
 	}

--- a/src/bytecodeparser/analysis/decoders/DecodedMethodInvocationOp.java
+++ b/src/bytecodeparser/analysis/decoders/DecodedMethodInvocationOp.java
@@ -106,7 +106,7 @@ public class DecodedMethodInvocationOp extends DecodedOp {
 				se = stack.pop2();
 			else se = stack.pop();
 		}
-		if(op.as(MethodInvocationOpcode.class).isInstanceMethod())
+        if (op.as(MethodInvocationOpcode.class).isInstanceMethod() && !stack.isEmpty())
 			stack.pop();
 		if(returnTypeLength != null) {
 			if(returnTypeLength == DOUBLE)

--- a/src/bytecodeparser/analysis/stack/StackAnalyzer.java
+++ b/src/bytecodeparser/analysis/stack/StackAnalyzer.java
@@ -113,7 +113,9 @@ public class StackAnalyzer {
 			Stack currentStack = stack.copy();
 			while(iterator.hasNext()) {
 				int index = iterator.next();
-				Op op = Opcodes.OPCODES.get(iterator.byteAt(index)).init(context, index);
+                Op opcode = Opcodes.OPCODES.get(iterator.byteAt(index));
+                if(opcode == null) continue;
+                Op op = opcode.init(context, index);
 				trace.append("\n").append(index).append(":").append(op.getName()).append(" --> ");
 				Frame frame = frames[index];
 				frame.isAccessible = true;


### PR DESCRIPTION
This makes possible to run playframework 1.3 with Java 8 and lambdas. INVOKEDYNAMIC opcode is not parsed and analyzed.
